### PR TITLE
Kill `Explore repositories` even after GitHub adding `dialog-helper`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ The filled enum is not perfect. It should contain URIs. But you can update as fo
 1. Download and extract and formats the <https://developer.chrome.com/docs/extensions/mv3/permission_warnings/> as `tmp/scrape.html`
 1. `rg '<tr id="([^"]+)">' -or '"$1",'  tmp/scrape.html` will show the most definitions, but not correct, and it includes non enum like URL patterns
 
+## Which timing is the best to execute?
+
+[This article](https://stackoverflow.com/questions/43233115/chrome-content-scripts-arent-working-domcontentloaded-listener-does-not-execut) may help you.
+
 ## Release
 
 1. Bump version in [manifest file](manifest.json)

--- a/src/github-patcher.css
+++ b/src/github-patcher.css
@@ -15,6 +15,6 @@ a:has(> img[data-canonical-src^='https://github-readme-stats.vercel.app/api?'])
 
 li:has(> a[href$='/followers']),
 div:has(> h2 a[href$='?tab=achievements']),
-div[aria-label='Explore repositories'] div:has(> svg[aria-label='star']) {
+aside[aria-label='Explore'] div[aria-label='Explore repositories'] div:has(> svg[aria-label='star']) {
   display: none !important;
 }

--- a/src/github-patcher.ts
+++ b/src/github-patcher.ts
@@ -54,4 +54,4 @@ const main = (): void => {
   }
 };
 
-document.addEventListener('load', main, { passive: true });
+document.addEventListener('DOMContentLoaded', main, { passive: true });

--- a/src/github-patcher.ts
+++ b/src/github-patcher.ts
@@ -9,10 +9,12 @@ const hide = (element: Element): void => {
 };
 
 const main = (): void => {
+  console.log(`executed main`);
   chrome.storage.sync.get([
     'isHideExploreRepositories',
     'isHideSponsors',
   ]).then((keys): void => {
+    console.log(`executed callback`);
     if (keys.isHideExploreRepositories) {
       const exploreRepositoriesComponent = document.querySelector(
         "div[aria-label='Explore repositories']",
@@ -21,6 +23,8 @@ const main = (): void => {
       if (exploreRepositoriesComponent) {
         hide(exploreRepositoriesComponent);
       }
+
+      console.log(`executed isHideExploreRepositories`);
     }
 
     if (keys.isHideSponsors) {
@@ -37,6 +41,8 @@ const main = (): void => {
       if (sponsorsComponent) {
         hide(sponsorsComponent);
       }
+
+      console.log(`executed isHideSponsors`);
     }
   });
 
@@ -52,6 +58,10 @@ const main = (): void => {
   if (highlightsComponent) {
     hide(highlightsComponent);
   }
+  console.log(`finished main`);
 };
 
-document.addEventListener('DOMContentLoaded', main, { passive: true });
+if (document.readyState !== 'complete') {
+  document.addEventListener('load', main, { passive: true });
+}
+main();

--- a/src/github-patcher.ts
+++ b/src/github-patcher.ts
@@ -16,12 +16,12 @@ const main = (): void => {
   ]).then((keys): void => {
     console.log(`executed callback`);
     if (keys.isHideExploreRepositories) {
-      const exploreRepositoriesComponents = document.querySelectorAll(
-        "div[aria-label='Explore repositories']",
+      const exploreRepositoriesComponent = document.querySelector(
+        "aside[aria-label='Explore'] div[aria-label='Explore repositories']",
       );
 
-      for (const component of exploreRepositoriesComponents) {
-        hide(component);
+      if (exploreRepositoriesComponent) {
+        hide(exploreRepositoriesComponent);
       }
 
       console.log(`executed isHideExploreRepositories`);

--- a/src/github-patcher.ts
+++ b/src/github-patcher.ts
@@ -8,46 +8,50 @@ const hide = (element: Element): void => {
   );
 };
 
-chrome.storage.sync.get([
-  'isHideExploreRepositories',
-  'isHideSponsors',
-]).then((keys): void => {
-  if (keys.isHideExploreRepositories) {
-    const exploreRepositoriesComponent = document.querySelector(
-      "div[aria-label='Explore repositories']",
-    );
+const main = (): void => {
+  chrome.storage.sync.get([
+    'isHideExploreRepositories',
+    'isHideSponsors',
+  ]).then((keys): void => {
+    if (keys.isHideExploreRepositories) {
+      const exploreRepositoriesComponent = document.querySelector(
+        "div[aria-label='Explore repositories']",
+      );
 
-    if (exploreRepositoriesComponent) {
-      hide(exploreRepositoriesComponent);
+      if (exploreRepositoriesComponent) {
+        hide(exploreRepositoriesComponent);
+      }
     }
-  }
 
-  if (keys.isHideSponsors) {
-    const sponsorsH2Node = document.evaluate(
-      "/html/body//div[@class='Layout-sidebar']//h2[text()='Sponsors']",
-      document,
-      null,
-      XPathResult.FIRST_ORDERED_NODE_TYPE,
-      null,
-    ).singleNodeValue;
+    if (keys.isHideSponsors) {
+      const sponsorsH2Node = document.evaluate(
+        "/html/body//div[@class='Layout-sidebar']//h2[text()='Sponsors']",
+        document,
+        null,
+        XPathResult.FIRST_ORDERED_NODE_TYPE,
+        null,
+      ).singleNodeValue;
 
-    const sponsorsComponent = sponsorsH2Node?.parentElement?.parentElement;
+      const sponsorsComponent = sponsorsH2Node?.parentElement?.parentElement;
 
-    if (sponsorsComponent) {
-      hide(sponsorsComponent);
+      if (sponsorsComponent) {
+        hide(sponsorsComponent);
+      }
     }
+  });
+
+  const highlightsH2Node = document.evaluate(
+    "/html/body//div[@class='Layout-sidebar']//h2[text()='Highlights']",
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null,
+  ).singleNodeValue;
+
+  const highlightsComponent = highlightsH2Node?.parentElement;
+  if (highlightsComponent) {
+    hide(highlightsComponent);
   }
-});
+};
 
-const highlightsH2Node = document.evaluate(
-  "/html/body//div[@class='Layout-sidebar']//h2[text()='Highlights']",
-  document,
-  null,
-  XPathResult.FIRST_ORDERED_NODE_TYPE,
-  null,
-).singleNodeValue;
-
-const highlightsComponent = highlightsH2Node?.parentElement;
-if (highlightsComponent) {
-  hide(highlightsComponent);
-}
+document.addEventListener('load', main, { passive: true });

--- a/src/github-patcher.ts
+++ b/src/github-patcher.ts
@@ -16,12 +16,12 @@ const main = (): void => {
   ]).then((keys): void => {
     console.log(`executed callback`);
     if (keys.isHideExploreRepositories) {
-      const exploreRepositoriesComponent = document.querySelector(
+      const exploreRepositoriesComponents = document.querySelectorAll(
         "div[aria-label='Explore repositories']",
       );
 
-      if (exploreRepositoriesComponent) {
-        hide(exploreRepositoriesComponent);
+      for (const component of exploreRepositoriesComponents) {
+        hide(component);
       }
 
       console.log(`executed isHideExploreRepositories`);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
-      "run_at": "document_end",
+      "run_at": "document_idle",
       "css": ["github-patcher.css"],
       "js": ["github-patcher.js"]
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
+      "run_at": "document_idle",
       "css": ["github-patcher.css"],
       "js": ["github-patcher.js"]
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
-      "run_at": "document_idle",
+      "run_at": "document_end",
       "css": ["github-patcher.css"],
       "js": ["github-patcher.js"]
     }


### PR DESCRIPTION
Fixes #93 

Unstable sponsors also might be completely removed...?